### PR TITLE
feat: add TS generics for better types

### DIFF
--- a/types/options.ts
+++ b/types/options.ts
@@ -967,12 +967,13 @@ export interface SequenceExpression extends ExpressionBase {
   expressions: Expression[];
 }
 
-export interface ArrowFunctionExpression extends ExpressionBase {
+export interface ArrowFunctionExpression<Expr extends Expression = Expression>
+  extends ExpressionBase {
   type: "ArrowFunctionExpression";
 
   params: Pattern[];
 
-  body: BlockStatement | Expression;
+  body: BlockStatement | Expr;
 
   async: boolean;
 

--- a/types/options.ts
+++ b/types/options.ts
@@ -849,19 +849,20 @@ export interface ObjectExpression extends ExpressionBase {
   properties: (Property | SpreadElement)[];
 }
 
-export interface Argument {
+export interface Argument<Expr extends Expression = Expression> {
   spread?: Span;
-  expression: Expression;
+  expression: Expr;
 }
 
 export type PropertOrSpread = Property | SpreadElement;
 
-export interface SpreadElement extends Node {
+export interface SpreadElement<Expr extends Expression = Expression>
+  extends Node {
   type: "SpreadElement";
 
   spread: Span;
 
-  arguments: Expression;
+  arguments: Expr;
 }
 
 export interface UnaryExpression extends ExpressionBase {
@@ -938,22 +939,24 @@ export interface Super extends Node, HasSpan {
   type: "Super";
 }
 
-export interface CallExpression extends ExpressionBase {
+export interface CallExpression<Expr extends Expression = Expression>
+  extends ExpressionBase {
   type: "CallExpression";
 
-  callee: Expression | Super;
+  callee: Expr | Super;
 
-  arguments: Argument[];
+  arguments: Argument<Expr>[];
 
   typeArguments?: TsTypeParameterInstantiation;
 }
 
-export interface NewExpression extends ExpressionBase {
+export interface NewExpression<Expr extends Expression = Expression>
+  extends ExpressionBase {
   type: "NewExpression";
 
   callee: Expression;
 
-  arguments: Argument[];
+  arguments: Argument<Expr>[];
 
   typeArguments?: TsTypeParameterInstantiation;
 }


### PR DESCRIPTION
Right now in one project I'm running into this issue where `expression.body` cannot have proper types due to `Argument` not being extendable through generics:

https://github.com/exhibitionist-digital/ultra/pull/5/files#diff-adb065f7ea26f7f005649ad48bcbf0534bc860c701bb4e19c3917b125f4e2f20R47-R50

this PR adds generics to some of the statements, including:

- `Argument<Expr>`
- `SpreadElement<Expr>`
- `CallExpression<Expr>`
- `NewExpression<Expr>`
- `ArrowFunctionExpression<Expr>`

If this PR gets a chance, I can add it for the remaining interfaces